### PR TITLE
Regex pdf

### DIFF
--- a/treaty_extract.py
+++ b/treaty_extract.py
@@ -4,26 +4,53 @@ import re
 import sys
 import itertools
 
-from bs4 import BeautifulSoup
-from requests_html import HTMLSession
 import PyPDF2
 
-def convert_to_txt(pdf_file):
+from io import StringIO
+
+from pdfminer.converter import TextConverter
+from pdfminer.layout import LAParams
+from pdfminer.pdfdocument import PDFDocument
+from pdfminer.pdfinterp import PDFResourceManager, PDFPageInterpreter
+from pdfminer.pdfpage import PDFPage
+from pdfminer.pdfparser import PDFParser
+
+import time 
+
+def convert_to_txt_pypdf(pdf_file):
     pdf_reader = PyPDF2.PdfFileReader(pdf_file)
     txt_file = os.path.splitext(pdf_file)[0] +'.txt'
     with open (txt_file,'w', encoding="utf-8") as pdf_output:
         for page in range(pdf_reader.getNumPages()):
             data = pdf_reader.getPage(page).extractText()
-            data_lines = data.splitlines()
-            data_string = ' '.join([str(elem) for elem in data_lines])
-            pdf_output.write(data_string)
+            pdf_output.write(data)
     with open(txt_file, 'r') as pdf_content:
         pdf_content.read().replace('\n', ' ')
 
-data_path = '/Users/josehernandez/Documents/eScience/projects/universe-of-treaties/data/'
+# Adapted from https://pdfminersix.readthedocs.io/en/latest/tutorial/composable.html
+def convert_to_txt_miner(pdf_path):
+    txt_file = os.path.splitext(file_path)[0] +'.txt'
+    output_string = StringIO()
+    with open(pdf_path, 'rb') as in_file:
+        parser = PDFParser(in_file)
+        doc = PDFDocument(parser)
+        rsrcmgr = PDFResourceManager()
+        device = TextConverter(rsrcmgr, output_string, laparams=LAParams())
+        interpreter = PDFPageInterpreter(rsrcmgr, device)
+        for page in PDFPage.create_pages(doc):
+            interpreter.process_page(page)
+        text = output_string.getvalue()
+    with open (txt_file,'w', encoding="utf-8") as pdf_output:
+        pdf_output.write(text)
 
-for pdf in os.listdir(data_path):
-    convert_to_txt(data_path+pdf)
+file_path = '/Users/josehernandez/Documents/eScience/projects/universe-of-treaties/data/v1.pdf'
 
-# test regex
-# begins with [No. #####] d{5}
+t = time.time() 
+convert_to_txt_pypdf(file_path)
+time.time() - t
+# 5.05s
+
+t = time.time() 
+convert_to_txt_miner(file_path)
+time.time() - t
+# 18.38s!! Yikes! 

--- a/treaty_extract.py
+++ b/treaty_extract.py
@@ -53,4 +53,4 @@ time.time() - t
 t = time.time() 
 convert_to_txt_miner(file_path)
 time.time() - t
-# 18.38s!! Yikes! 
+# 18.38s!! Yikes!

--- a/treaty_extract.py
+++ b/treaty_extract.py
@@ -14,7 +14,9 @@ def convert_to_txt(pdf_file):
     with open (txt_file,'w', encoding="utf-8") as pdf_output:
         for page in range(pdf_reader.getNumPages()):
             data = pdf_reader.getPage(page).extractText()
-            pdf_output.write(data)
+            data_lines = data.splitlines()
+            data_string = ' '.join([str(elem) for elem in data_lines])
+            pdf_output.write(data_string)
     with open(txt_file, 'r') as pdf_content:
         pdf_content.read().replace('\n', ' ')
 

--- a/txt_treaty_cleanup.py
+++ b/txt_treaty_cleanup.py
@@ -1,0 +1,20 @@
+# Treaty text cleanup 
+# Remove non english words
+# Clean up characters and non-word items
+import re 
+import nltk
+nltk.download('words')
+words = set(nltk.corpus.words.words())
+
+# Remove non-english using NLTK
+
+test = '''
+Note by the SecretariatandRegulations to give effect to Article 102of the 
+Charter of the United Nations,adopted by the General Assembly on 
+14 December Traitds ou accords internationaux transmis par un 
+Membrtde 'Organisation des Nations Unies et conclus avant la date.
+'''
+
+test = re.findall('[A-Z][^A-Z]*', test)
+test = ' '.join(test)
+test = " ".join(w for w in nltk.wordpunct_tokenize(test) if w.lower() in words or not w.isalpha())


### PR DESCRIPTION
Hi @breebangjensen 
- Regex of text by volume will not be explored (thank you Spencer and Bree for scraping individual files!)
- `PyPDF` seems viable in terms of efficiency 
- `pdfminer` is too slow, but can explore making it more efficient (code-wise)
- added template script `txt_treaty_cleanup.py` to develop the processing post scraping and text extraction, starting with removal of non-english text (french and other languages). Will build on this step in separate branch.  